### PR TITLE
Add Safety fallback, incase filename is empty

### DIFF
--- a/proxyhunter.py
+++ b/proxyhunter.py
@@ -5,7 +5,12 @@ from concurrent.futures import ThreadPoolExecutor
 print("ProxyHunter - Made By D3fu1t\n")
 
 # Ask for the filename before starting
-filename = input("Enter file name to save live proxies (e.g., proxies.txt): ")
+filename = input("Enter file name to save live proxies (Default, proxies.txt): ")
+
+# Safety fallback, incase filename is empty
+if (filename == ""):
+    filename = "proxies.txt"
+        
 
 # Proxy sources
 PROXY_SOURCES = [


### PR DESCRIPTION
To ommit the `FileNotFoundError: [Errno 2] No such file or directory: ''` added Safety fallback which will make the default file name to proxies.txt on condition if user does not provide any file name, This ensure reliability and flexibility of this tool.